### PR TITLE
fix #3 プロフィールセルを作成

### DIFF
--- a/SamplePhoneBook.xcodeproj/project.pbxproj
+++ b/SamplePhoneBook.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		E36BF2EC25B9664500894C57 /* ProfileListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E36BF2EB25B9664500894C57 /* ProfileListView.swift */; };
 		E36BF2F025B9674700894C57 /* CreateProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E36BF2EF25B9674700894C57 /* CreateProfileView.swift */; };
+		E36BF30E25BAB2CB00894C57 /* ProfileCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E36BF30D25BAB2CB00894C57 /* ProfileCellView.swift */; };
 		E39BA00125B0603E00299A32 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E39BA00025B0603E00299A32 /* AppDelegate.swift */; };
 		E39BA00325B0603E00299A32 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E39BA00225B0603E00299A32 /* SceneDelegate.swift */; };
 		E39BA00525B0603E00299A32 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E39BA00425B0603E00299A32 /* ContentView.swift */; };
@@ -19,6 +20,7 @@
 /* Begin PBXFileReference section */
 		E36BF2EB25B9664500894C57 /* ProfileListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileListView.swift; sourceTree = "<group>"; };
 		E36BF2EF25B9674700894C57 /* CreateProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateProfileView.swift; sourceTree = "<group>"; };
+		E36BF30D25BAB2CB00894C57 /* ProfileCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileCellView.swift; sourceTree = "<group>"; };
 		E39B9FFD25B0603E00299A32 /* SamplePhoneBook.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SamplePhoneBook.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		E39BA00025B0603E00299A32 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		E39BA00225B0603E00299A32 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -63,6 +65,7 @@
 				E39BA00425B0603E00299A32 /* ContentView.swift */,
 				E36BF2EB25B9664500894C57 /* ProfileListView.swift */,
 				E36BF2EF25B9674700894C57 /* CreateProfileView.swift */,
+				E36BF30D25BAB2CB00894C57 /* ProfileCellView.swift */,
 				E39BA00625B0604400299A32 /* Assets.xcassets */,
 				E39BA00B25B0604400299A32 /* LaunchScreen.storyboard */,
 				E39BA00E25B0604400299A32 /* Info.plist */,
@@ -139,6 +142,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E36BF30E25BAB2CB00894C57 /* ProfileCellView.swift in Sources */,
 				E36BF2EC25B9664500894C57 /* ProfileListView.swift in Sources */,
 				E39BA00125B0603E00299A32 /* AppDelegate.swift in Sources */,
 				E39BA00325B0603E00299A32 /* SceneDelegate.swift in Sources */,

--- a/SamplePhoneBook.xcodeproj/project.pbxproj
+++ b/SamplePhoneBook.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		E36BF2EC25B9664500894C57 /* ProfileListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E36BF2EB25B9664500894C57 /* ProfileListView.swift */; };
 		E36BF2F025B9674700894C57 /* CreateProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E36BF2EF25B9674700894C57 /* CreateProfileView.swift */; };
 		E36BF30E25BAB2CB00894C57 /* ProfileCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E36BF30D25BAB2CB00894C57 /* ProfileCellView.swift */; };
+		E36BF37525C0843300894C57 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E36BF37425C0843300894C57 /* Preview Assets.xcassets */; };
 		E39BA00125B0603E00299A32 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E39BA00025B0603E00299A32 /* AppDelegate.swift */; };
 		E39BA00325B0603E00299A32 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E39BA00225B0603E00299A32 /* SceneDelegate.swift */; };
 		E39BA00525B0603E00299A32 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E39BA00425B0603E00299A32 /* ContentView.swift */; };
@@ -21,6 +22,7 @@
 		E36BF2EB25B9664500894C57 /* ProfileListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileListView.swift; sourceTree = "<group>"; };
 		E36BF2EF25B9674700894C57 /* CreateProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateProfileView.swift; sourceTree = "<group>"; };
 		E36BF30D25BAB2CB00894C57 /* ProfileCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileCellView.swift; sourceTree = "<group>"; };
+		E36BF37425C0843300894C57 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		E39B9FFD25B0603E00299A32 /* SamplePhoneBook.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SamplePhoneBook.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		E39BA00025B0603E00299A32 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		E39BA00225B0603E00299A32 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -41,6 +43,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		E36BF37325C0843300894C57 /* Preview Content */ = {
+			isa = PBXGroup;
+			children = (
+				E36BF37425C0843300894C57 /* Preview Assets.xcassets */,
+			);
+			path = "Preview Content";
+			sourceTree = "<group>";
+		};
 		E39B9FF425B0603D00299A32 = {
 			isa = PBXGroup;
 			children = (
@@ -69,6 +79,7 @@
 				E39BA00625B0604400299A32 /* Assets.xcassets */,
 				E39BA00B25B0604400299A32 /* LaunchScreen.storyboard */,
 				E39BA00E25B0604400299A32 /* Info.plist */,
+				E36BF37325C0843300894C57 /* Preview Content */,
 			);
 			path = SamplePhoneBook;
 			sourceTree = "<group>";
@@ -131,6 +142,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E39BA00D25B0604400299A32 /* LaunchScreen.storyboard in Resources */,
+				E36BF37525C0843300894C57 /* Preview Assets.xcassets in Resources */,
 				E39BA00725B0604400299A32 /* Assets.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/SamplePhoneBook/CreateProfileView.swift
+++ b/SamplePhoneBook/CreateProfileView.swift
@@ -10,9 +10,15 @@ import SwiftUI
 struct CreateProfileView: View {
     var body: some View {
         NavigationView {
-            ZStack {
-                Color(#colorLiteral(red: 0.5974730564, green: 0.799616446, blue: 0.9255421162, alpha: 1))
+            VStack {
             }
+            //背景色の設定
+            .frame(minWidth: 0,
+                   maxWidth: .infinity,
+                   minHeight: 0,
+                   maxHeight: .infinity)
+            .background(Color(#colorLiteral(red: 0.5974730564, green: 0.799616446, blue: 0.9255421162, alpha: 1)))
+            //NavigationBarの設定
             .navigationBarItems(leading: Image(systemName: "person.circle.fill"))
             .navigationBarTitle("プロフィール登録", displayMode: .inline)
         }

--- a/SamplePhoneBook/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/SamplePhoneBook/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SamplePhoneBook/ProfileCellView.swift
+++ b/SamplePhoneBook/ProfileCellView.swift
@@ -1,0 +1,29 @@
+//
+//  ProfileCellView.swift
+//  SamplePhoneBook
+//
+//  Created by AYANO HARA on 2021/01/22.
+//
+
+import SwiftUI
+
+struct ProfileCellView: View {
+    var body: some View {
+        HStack {
+            Image(systemName: "person.circle")
+                .resizable()
+                .frame(width: 50, height: 80)
+            Text("愛知 太郎")
+                .font(.title2)
+                .fontWeight(.bold)
+            Spacer()
+        }
+    }
+}
+
+struct ProfileCellView_Previews: PreviewProvider {
+    static var previews: some View {
+        ProfileCellView()
+            .previewLayout(.fixed(width: 300, height: 100))
+    }
+}

--- a/SamplePhoneBook/ProfileCellView.swift
+++ b/SamplePhoneBook/ProfileCellView.swift
@@ -12,12 +12,21 @@ struct ProfileCellView: View {
         HStack {
             Image(systemName: "person.circle")
                 .resizable()
-                .frame(width: 50, height: 80)
+                .frame(width: 70, height: 70)
             Text("愛知 太郎")
                 .font(.title2)
                 .fontWeight(.bold)
             Spacer()
         }
+        .padding()
+        .background(Color(#colorLiteral(red: 1, green: 1, blue: 1, alpha: 1)))
+        .cornerRadius(20)
+        .shadow(color: .gray, radius: 3, x: 10, y: 10)
+        
+        .overlay(
+            RoundedRectangle(cornerRadius: 20)
+                .stroke(Color.black, lineWidth: 1)
+        )
     }
 }
 

--- a/SamplePhoneBook/ProfileCellView.swift
+++ b/SamplePhoneBook/ProfileCellView.swift
@@ -34,5 +34,6 @@ struct ProfileCellView_Previews: PreviewProvider {
     static var previews: some View {
         ProfileCellView()
             .previewLayout(.fixed(width: 300, height: 100))
+            .padding()
     }
 }

--- a/SamplePhoneBook/ProfileListView.swift
+++ b/SamplePhoneBook/ProfileListView.swift
@@ -10,9 +10,15 @@ import SwiftUI
 struct ProfileListView: View {
     var body: some View {
         NavigationView {
-            ZStack {
-                Color(#colorLiteral(red: 0.5974730564, green: 0.799616446, blue: 0.9255421162, alpha: 1))
+            VStack {
             }
+            //背景色の設定
+            .frame(minWidth: 0,
+                   maxWidth: .infinity,
+                   minHeight: 0,
+                   maxHeight: .infinity)
+            .background(Color(#colorLiteral(red: 0.5974730564, green: 0.799616446, blue: 0.9255421162, alpha: 1)))
+            //NavigationBarの設定
             .navigationBarItems(leading: Image(systemName: "list.dash"))
             .navigationBarTitle("プロフィール一覧", displayMode: .inline)
         }


### PR DESCRIPTION
## 概要
・プロフィールセルを作成
・消えてしまったファイルを復元

## プロフィールセルのUI
<img width="250" alt="スクリーンショット 2021-01-28 15 46 43" src="https://user-images.githubusercontent.com/65425673/106102045-23d90500-6182-11eb-97c6-ded3f3f1830b.png">  
<img width="250" alt="スクリーンショット 2021-01-28 15 46 30" src="https://user-images.githubusercontent.com/65425673/106102058-29cee600-6182-11eb-9b64-0071cd50bba9.png">


## 補足
Preview Contentのフォルダごといつの間にか削除してしまっていて、それが原因でシュミレーターでのビルドができなかったのでフォルダを復元しました💧
